### PR TITLE
Implement recent command

### DIFF
--- a/msbot/constants.py
+++ b/msbot/constants.py
@@ -19,10 +19,13 @@ TOKEN = 'hub.verify_token'
 CHALLENGE = 'hub.challenge'
 SUBSCRIBE = 'subscribe'
 
+# Commands
 HELLO = 'hello'
 GOODBYE = 'goodbye'
 SEND = 'send'
+RECENT = 'recent'
 
+# Responses
 RESP_SUBBED = 'You are now subscribed. Say "goodbye" at any time to unsubscribe'
 RESP_UNSUBBED = 'You have been unsubscribed from MythicSpoilerBot'
 RESP_ALREADY_SUBBED = 'You are already subscribed'
@@ -31,7 +34,9 @@ RESP_INVALID_UNSUBBED = 'Invalid command. Say "hello" at any time to subscribe'
 RESP_INVALID_SUBBED = 'Invalid command. Say "goodbye" at any time to unsubscribe'
 RESP_UPDATE = (
     "New spoilers are out! You have {num_spoilers} unseen spoiler(s). "
-    "Type '" + SEND + "' to receive your spoilers"
+    "Type '" + SEND + "' to receive all pending spoilers, or type '" + RECENT +
+    "' to get just the most recent ones and mark the rest as seen."
 )
+RESP_LAST_SPOILER_INFO = "These spoilers were released on {date_string} "
 RESP_UPDATE_UPDATED = 'No new spoilers :('
 RESP_UPDATE_COMPLETE = 'You are now up to date'

--- a/msbot/constants.py
+++ b/msbot/constants.py
@@ -26,15 +26,15 @@ SEND = 'send'
 RECENT = 'recent'
 
 # Responses
-RESP_SUBBED = 'You are now subscribed. Say "goodbye" at any time to unsubscribe'
+RESP_SUBBED = "You are now subscribed. Say 'goodbye' at any time to unsubscribe"
 RESP_UNSUBBED = 'You have been unsubscribed from MythicSpoilerBot'
 RESP_ALREADY_SUBBED = 'You are already subscribed'
 RESP_ALREADY_UNSUBBED = 'You are not subscribed'
-RESP_INVALID_UNSUBBED = 'Invalid command. Say "hello" at any time to subscribe'
-RESP_INVALID_SUBBED = 'Invalid command. Say "goodbye" at any time to unsubscribe'
+RESP_INVALID_UNSUBBED = "Invalid command. Say 'hello' at any time to subscribe"
+RESP_INVALID_SUBBED = "Invalid command. Say 'recent' to get the latest batch of spoilers and say 'goodbye' at any time to unsubscribe"
 RESP_UPDATE = (
     "New spoilers are out! You have {num_spoilers} unseen spoiler(s). "
-    "Type '" + SEND + "' to receive all pending spoilers, or type '" + RECENT +
+    "Say '" + SEND + "' to receive all pending spoilers, or say '" + RECENT +
     "' to get just the most recent ones and mark the rest as seen."
 )
 RESP_LAST_SPOILER_INFO = "These spoilers were released on {date_string} "

--- a/msbot/msdb.py
+++ b/msbot/msdb.py
@@ -88,6 +88,17 @@ class MSDatabase(Database):
         (latest_id,) = self.fetchone()
         return latest_id if latest_id != None else 0
 
+    def get_latest_spoiler_date(self):
+        sql = 'SELECT MAX(date_spoiled) FROM spoilers'
+        self.query(sql)
+        (date,) = self.fetchone()
+        return date
+
+    def get_all_spoilers_on_date(self, date):
+        sql = "SELECT * FROM spoilers WHERE date_spoiled = '{date}'".format(date=date)
+        self.query(sql)
+        return [ Spoiler(row) for row in self.fetchall() ]
+
     def get_all_spoilers(self):
         sql = 'SELECT * FROM spoilers'
         self.query(sql)

--- a/tests/test_msdb.py
+++ b/tests/test_msdb.py
@@ -186,6 +186,34 @@ class TestMSDatabase(unittest.TestCase):
 
         self.assertEqual(self.test_db.get_latest_spoiler_id(), 4)
 
+    def test_get_latest_spoiler_date(self):
+        spoil1 = Spoiler(('test1', 'attach1', '2019-01-01', 1))
+        spoil2 = Spoiler(('test2', 'attach2', '2019-01-02', 2))
+        spoil3 = Spoiler(('test3', 'attach3', '2018-01-01', 3))
+
+        mock_spoilers = [spoil1, spoil2, spoil3]
+
+        for s in mock_spoilers:
+            self.insert_spoiler(s)
+
+        self.assertEqual(self.test_db.get_latest_spoiler_date(), '2019-01-02')
+
+
+    def test_get_all_spoilers_on_date(self):
+        spoil1 = Spoiler(('test1', 'attach1', '2019-01-01', 1))
+        spoil2 = Spoiler(('test2', 'attach2', '2019-01-02', 2))
+        spoil3 = Spoiler(('test3', 'attach3', '2019-01-02', 3))
+
+        mock_spoilers = [spoil1, spoil2, spoil3]
+
+        for s in mock_spoilers:
+            self.insert_spoiler(s)
+
+        self.assertCountEqual(
+            self.test_db.get_all_spoilers_on_date('2019-01-02'),
+            [spoil2, spoil3]
+        )
+
     def test_get_all_spoilers(self):
         mock_spoilers = [
             Spoiler(('test1', 'attach1', '2019-01-01', 1)),

--- a/webhook.py
+++ b/webhook.py
@@ -119,10 +119,27 @@ def handle_message(sender_psid, received_message):
             return msbot.constants.RESP_UPDATE_COMPLETE
         return msbot.constants.RESP_INVALID_UNSUBBED
 
+    def recent(sender_psid):
+        if database.user_exists(sender_psid):
+            user = database.get_user_from_id(sender_psid)
+            last_spoiler = database.get_latest_spoiler_id()
+            last_spoil_date = database.get_latest_spoiler_date()
+            spoilers = database.get_all_spoilers_on_date(last_spoil_date)
+            for spoiler in spoilers:
+                send_spoiler_to(user, spoiler)
+            database.update_user(
+                user.user_id,
+                last_updated=last_spoiler,
+                last_spoiled=last_spoiler
+            )
+            return msbot.constants.RESP_LAST_SPOILER_INFO.format(date_string=last_spoil_date)
+        return msbot.constants.RESP_INVALID_UNSUBBED
+
     responses = {
         msbot.constants.HELLO: lambda id: subscribe(id),
         msbot.constants.GOODBYE: lambda id: unsubscribe(id),
         msbot.constants.SEND: lambda id: send(id),
+        msbot.constants.RECENT: lambda id: recent(id),
     }
     message = received_message.lower()
     if message in responses:


### PR DESCRIPTION
The RECENT text command allows users to query all spoilers from the last date spoilers were released.

It also makes the user up-to-date in the database, setting their last_spoiled number up to the current number.

This feature closes off on #14 