### PR TITLE
Replaces update prompt with quick reply

### DIFF
--- a/msbot/constants.py
+++ b/msbot/constants.py
@@ -19,10 +19,15 @@ TOKEN = 'hub.verify_token'
 CHALLENGE = 'hub.challenge'
 SUBSCRIBE = 'subscribe'
 
+QUICK_REPLIES = 'quick_replies'
+CONTENT_TYPE = 'content_type'
+TITLE = 'title'
+PAYLOAD = 'payload'
+
 # Commands
 HELLO = 'hello'
 GOODBYE = 'goodbye'
-SEND = 'send'
+SEND = 'all'
 RECENT = 'recent'
 
 # Responses
@@ -31,11 +36,12 @@ RESP_UNSUBBED = 'You have been unsubscribed from MythicSpoilerBot'
 RESP_ALREADY_SUBBED = 'You are already subscribed'
 RESP_ALREADY_UNSUBBED = 'You are not subscribed'
 RESP_INVALID_UNSUBBED = "Invalid command. Say 'hello' at any time to subscribe"
-RESP_INVALID_SUBBED = "Invalid command. Say 'recent' to get the latest batch of spoilers and say 'goodbye' at any time to unsubscribe"
+RESP_INVALID_SUBBED = "Invalid command. Say 'recent' to get the latest batch of spoilers or say 'goodbye' at any time to unsubscribe"
 RESP_UPDATE = (
-    "New spoilers are out! You have {num_spoilers} unseen spoiler(s). "
-    "Say '" + SEND + "' to receive all pending spoilers, or say '" + RECENT +
-    "' to get just the most recent ones and mark the rest as seen."
+    "New spoilers are out! You have {num_spoilers} unseen spoiler(s).\n\n"
+    "Choose the '" + SEND.capitalize() + "' or '" + RECENT.capitalize() +
+    "' buttons below.\n\n" + SEND.capitalize() + " - Receive all unseen spoilers\n\n"
+    + RECENT.capitalize() + " - Receive most recent spoilers and mark remaining as seen"
 )
 RESP_LAST_SPOILER_INFO = "These spoilers were released on {date_string} "
 RESP_UPDATE_UPDATED = 'No new spoilers :('

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -119,7 +119,7 @@ class TestWebhook(unittest.TestCase):
         self.assertEqual(db.add_spoiler.call_count, len(calls))
 
     @mock.patch('msbot.msdb.MSDatabase')
-    @mock.patch('webhook.send_text_message')
+    @mock.patch('webhook.send_update')
     def test_update_users(self, send_mock, db_mock):
         db = db_mock.return_value
 

--- a/webhook.py
+++ b/webhook.py
@@ -31,6 +31,23 @@ def send_message(sender_psid, response):
 def send_text_message(sender_psid, text):
     send_message(sender_psid, { msbot.constants.TEXT: text})
 
+def create_quick_reply_button(payload):
+    return {
+        msbot.constants.CONTENT_TYPE: msbot.constants.TEXT,
+        msbot.constants.TITLE: payload.capitalize(),
+        msbot.constants.PAYLOAD: payload,
+    }
+
+def send_update(sender_psid, text):
+    resp = {
+        msbot.constants.TEXT: text,
+        msbot.constants.QUICK_REPLIES: [
+            create_quick_reply_button(msbot.constants.SEND),
+            create_quick_reply_button(msbot.constants.RECENT),
+        ]
+    }
+    send_message(sender_psid, resp)
+
 def get_attach_id_for(image_url):
     print('Getting attach id for ', image_url)
     body = {
@@ -81,7 +98,7 @@ def update_users():
     for user in unnotified_users:
         num_spoilers = last_spoiler - user.last_spoiled
         resp = msbot.constants.RESP_UPDATE.format(num_spoilers=num_spoilers)
-        send_text_message(user.user_id, resp)
+        send_update(user.user_id, resp)
         db.update_user(user.user_id, last_updated=last_spoiler)
 
 #send updates from MythicSpoiler every 10 minutes


### PR DESCRIPTION
This PR implements part of #23 and replaces the current update prompt with buttons that can be easily tapped rather than having to manually type out the MSBot command.