### PR TITLE
Adds user options for update mode

### DIFF
--- a/msbot/constants.py
+++ b/msbot/constants.py
@@ -51,10 +51,11 @@ RESP_LAST_SPOILER_INFO = "These spoilers were released on {date_string} "
 RESP_UPDATE_UPDATED = 'No new spoilers :('
 RESP_UPDATE_COMPLETE = 'You are now up to date'
 RESP_MODE_PROMPT = (
-    "Change your update mode! Your current update mode is {update_mode}.\n\n"
+    "Change your update mode! Your current update mode is '{update_mode}'.\n\n"
     "Choose the '" + POLL_MODE_CMD.capitalize() + "' or '" + ASAP_MODE_CMD.capitalize() +
-    "' buttons below.\n\n" + POLL_MODE_CMD.capitalize() + " - When new spoilers are"
-    "available, I'll send a prompt so you can get spoilers at your pace.\n\n"
-    + ASAP_MODE_CMD.capitalize() + "'When new spoilers are available, I'll send you "
-    "the spoilers as soon as I get them so you can get spoilers ASAP_MODE."
+    "' buttons below.\n\n" + POLL_MODE_CMD.capitalize() + " - When new spoilers are "
+    "available, I'll send a prompt so you can get spoilers at your pace\n\n"
+    + ASAP_MODE_CMD.capitalize() + " - When new spoilers are available, I'll send you "
+    "the spoilers as soon as I get them so you can get spoilers ASAP"
 )
+RESP_MODE_COMPLETE = "Your update mode is now '{update_mode}'"

--- a/msbot/constants.py
+++ b/msbot/constants.py
@@ -29,6 +29,9 @@ HELLO = 'hello'
 GOODBYE = 'goodbye'
 SEND = 'all'
 RECENT = 'recent'
+UPDATE_MODE = 'update_mode'
+POLL_MODE = 'poll'
+ASAP_MODE = 'asap'
 
 # Responses
 RESP_SUBBED = "You are now subscribed. Say 'goodbye' at any time to unsubscribe"

--- a/msbot/constants.py
+++ b/msbot/constants.py
@@ -23,15 +23,16 @@ QUICK_REPLIES = 'quick_replies'
 CONTENT_TYPE = 'content_type'
 TITLE = 'title'
 PAYLOAD = 'payload'
+UPDATE_MODE = 'update_mode'
 
 # Commands
-HELLO = 'hello'
-GOODBYE = 'goodbye'
-SEND = 'all'
-RECENT = 'recent'
-UPDATE_MODE = 'update_mode'
-POLL_MODE = 'poll'
-ASAP_MODE = 'asap'
+HELLO_CMD = 'hello'
+GOODBYE_CMD = 'goodbye'
+SEND_CMD = 'all'
+RECENT_CMD = 'recent'
+MODE_CMD = 'mode'
+POLL_MODE_CMD = 'poll'
+ASAP_MODE_CMD = 'asap'
 
 # Responses
 RESP_SUBBED = "You are now subscribed. Say 'goodbye' at any time to unsubscribe"
@@ -42,10 +43,18 @@ RESP_INVALID_UNSUBBED = "Invalid command. Say 'hello' at any time to subscribe"
 RESP_INVALID_SUBBED = "Invalid command. Say 'recent' to get the latest batch of spoilers or say 'goodbye' at any time to unsubscribe"
 RESP_UPDATE = (
     "New spoilers are out! You have {num_spoilers} unseen spoiler(s).\n\n"
-    "Choose the '" + SEND.capitalize() + "' or '" + RECENT.capitalize() +
-    "' buttons below.\n\n" + SEND.capitalize() + " - Receive all unseen spoilers\n\n"
-    + RECENT.capitalize() + " - Receive most recent spoilers and mark remaining as seen"
+    "Choose the '" + SEND_CMD.capitalize() + "' or '" + RECENT_CMD.capitalize() +
+    "' buttons below.\n\n" + SEND_CMD.capitalize() + " - Receive all unseen spoilers\n\n"
+    + RECENT_CMD.capitalize() + " - Receive most recent spoilers and mark remaining as seen"
 )
 RESP_LAST_SPOILER_INFO = "These spoilers were released on {date_string} "
 RESP_UPDATE_UPDATED = 'No new spoilers :('
 RESP_UPDATE_COMPLETE = 'You are now up to date'
+RESP_MODE_PROMPT = (
+    "Change your update mode! Your current update mode is {update_mode}.\n\n"
+    "Choose the '" + POLL_MODE_CMD.capitalize() + "' or '" + ASAP_MODE_CMD.capitalize() +
+    "' buttons below.\n\n" + POLL_MODE_CMD.capitalize() + " - When new spoilers are"
+    "available, I'll send a prompt so you can get spoilers at your pace.\n\n"
+    + ASAP_MODE_CMD.capitalize() + "'When new spoilers are available, I'll send you "
+    "the spoilers as soon as I get them so you can get spoilers ASAP_MODE."
+)

--- a/msbot/msdb.py
+++ b/msbot/msdb.py
@@ -33,8 +33,13 @@ class MSDatabase(Database):
         self.query(sql)
         return [ User(row) for row in self.fetchall() ]
 
-    def update_user(self, user_id, last_updated=None, last_spoiled=None):
-        if last_updated == None and last_spoiled == None:
+    def update_user(self,
+                    user_id,
+                    last_updated=None,
+                    last_spoiled=None,
+                    options=None
+    ):
+        if last_updated == None and last_spoiled == None and options == None:
             return
 
         update_strings = []
@@ -44,6 +49,17 @@ class MSDatabase(Database):
 
         if last_spoiled != None:
             update_strings.append('last_spoiled = {}'.format(last_spoiled))
+
+        if options != None:
+            sql = "SELECT options FROM users where id = '{}'".format(user_id)
+            self.query(sql)
+            (json_string,) = self.fetchone()
+            user_options = json.loads(json_string)
+            for key, value in options.items():
+                user_options[key] = value
+            update_strings.append(
+                "options = '{}'".format(json.dumps(user_options))
+            )
 
         update_string = ','.join(update_strings)
 

--- a/msbot/msdb.py
+++ b/msbot/msdb.py
@@ -1,6 +1,10 @@
+import json
+import msbot.constants
+
 from msbot.db import Database
 from msbot.spoiler import Spoiler
 from msbot.user import User
+from msbot.user_options import UserOptions
 
 
 class MSDatabase(Database):
@@ -61,10 +65,13 @@ class MSDatabase(Database):
 
     def add_user(self, user_id):
         latest_spoiler = self.get_latest_spoiler_id()
-        sql = "INSERT INTO users VALUES('{user_id}', '{last_updated}', '{last_spoiled}')".format(
+        sql = "INSERT INTO users VALUES('{user_id}', '{last_updated}', '{last_spoiled}', '{options_json}')".format(
             user_id=user_id,
             last_updated=latest_spoiler,
             last_spoiled=latest_spoiler,
+            options_json=json.dumps(
+                UserOptions.default_options()
+            )
         )
         self.write(sql)
 
@@ -126,6 +133,7 @@ class MSDatabase(Database):
             id varchar(250) NOT NULL,
             last_updated INTEGER NOT NULL,
             last_spoiled INTEGER NOT NULL,
+            options JSON NOT NULL,
             FOREIGN KEY (last_updated) REFERENCES spoiler(id),
             FOREIGN KEY (last_spoiled) REFERENCES spoiler(id)
         )

--- a/msbot/user.py
+++ b/msbot/user.py
@@ -1,14 +1,19 @@
+from msbot.user_options import UserOptions
+
 class User:
     def __init__(self, row_tuple):
-        (self.user_id, self.last_updated, self.last_spoiled) = row_tuple
+        (self.user_id, self.last_updated, self.last_spoiled, options_string) = row_tuple
+        self.options = UserOptions(options_string)
 
     def __repr__(self):
         return ("<User object - id: {user_id}, "
                 "last_updated: {last_updated}, "
-                "last_spoiled: {last_spoiled}>").format(
+                "last_updated: {last_updated}, "
+                "options: {options}>").format(
                     user_id=self.user_id,
                     last_updated=self.last_updated,
-                    last_spoiled=self.last_spoiled
+                    last_spoiled=self.last_spoiled,
+                    options=self.options
                 )
 
     def __eq__(self, other):
@@ -16,4 +21,5 @@ class User:
             return NotImplemented
         return (self.user_id == other.user_id and
                 self.last_updated == self.last_updated and
-                self.last_spoiled == other.last_spoiled)
+                self.last_spoiled == other.last_spoiled and
+                self.options == other.options)

--- a/msbot/user_options.py
+++ b/msbot/user_options.py
@@ -1,0 +1,35 @@
+import json
+import msbot.constants
+
+class UserOptions:
+    def __init__(self, json_string):
+        options = json.loads(json_string)
+        if not options:
+            options = self.default_options()
+        self.update_mode = options[msbot.constants.UPDATE_MODE]
+
+    @staticmethod
+    def default_options():
+        return {
+            msbot.constants.UPDATE_MODE: msbot.constants.POLL_MODE_CMD
+        }
+
+    def to_json(self):
+        return {
+            msbot.constants.UPDATE_MODE: self.update_mode
+        }
+
+    def to_json_string(self):
+        return json.dumps(self.to_json())
+
+    def __repr__(self):
+        return ("<UserOptions object - update_mode: {update_mode}>"
+                .format(
+                    update_mode=self.update_mode
+                )
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, UserOptions):
+            return NotImplemented
+        return self.update_mode == other.update_mode

--- a/tests/test_msdb.py
+++ b/tests/test_msdb.py
@@ -22,7 +22,7 @@ class TestMSDatabase(unittest.TestCase):
         self.addCleanup(cleanup_test_db)
 
     def test_get_user_from_id(self):
-        user = User(('Alice', 0, 0))
+        user = User(('Alice', 0, 0, '{}'))
         self.insert_user(user)
         self.assertEqual(user, self.test_db.get_user_from_id('Alice'))
 
@@ -33,9 +33,9 @@ class TestMSDatabase(unittest.TestCase):
 
     def test_get_all_users(self):
         mock_users = [
-            User(('Alice', 0, 0)),
-            User(('Bob', 1, 1)),
-            User(('Carol', 2, 2)),
+            User(('Alice', 0, 0, '{}')),
+            User(('Bob', 1, 1, '{}')),
+            User(('Carol', 2, 2, '{}')),
         ]
 
         for user in mock_users:
@@ -55,7 +55,7 @@ class TestMSDatabase(unittest.TestCase):
 
         for mock_id in mock_user_ids:
             self.test_db.write(
-                "INSERT INTO users VALUES('{mock_id}', 0, 0)".format(mock_id=mock_id)
+                "INSERT INTO users VALUES('{mock_id}', 0, 0, '{{}}')".format(mock_id=mock_id)
             )
 
         self.assertEqual(
@@ -64,9 +64,9 @@ class TestMSDatabase(unittest.TestCase):
         )
 
     def test_get_all_unnotified_users(self):
-        alice = User(('Alice', 0, 2))
-        bob = User(('Bob', 1, 0))
-        carol = User(('Carol', 2, 1))
+        alice = User(('Alice', 0, 2, '{}'))
+        bob = User(('Bob', 1, 0, '{}'))
+        carol = User(('Carol', 2, 1, '{}'))
 
         mock_users = [alice, bob, carol]
 
@@ -84,26 +84,26 @@ class TestMSDatabase(unittest.TestCase):
         self.assertCountEqual(self.test_db.get_all_unnotified_users(), [alice, bob])
 
     def test_update_user(self):
-        user = User(('Alice', 0, 0))
+        user = User(('Alice', 0, 0, '{}'))
         self.insert_user(user)
 
         self.assertEqual(self.test_db.get_user_from_id('Alice'), user)
 
         self.test_db.update_user('Alice', last_updated=10)
 
-        changed_user = User(('Alice', 10, 0))
+        changed_user = User(('Alice', 10, 0, '{}'))
 
         self.assertEqual(self.test_db.get_user_from_id('Alice'), changed_user)
 
         self.test_db.update_user('Alice', last_spoiled=10)
 
-        changed_user = User(('Alice', 10, 10))
+        changed_user = User(('Alice', 10, 10, '{}'))
 
         self.assertEqual(self.test_db.get_user_from_id('Alice'), changed_user)
 
         self.test_db.update_user('Alice', last_updated= 15, last_spoiled=15)
 
-        changed_user = User(('Alice', 15, 15))
+        changed_user = User(('Alice', 15, 15, '{}'))
 
         self.assertEqual(self.test_db.get_user_from_id('Alice'), changed_user)
 
@@ -117,7 +117,7 @@ class TestMSDatabase(unittest.TestCase):
         test_user = 'test_user_id'
         self.assertFalse(self.test_db.user_exists(test_user))
         self.test_db.write(
-            "INSERT INTO users VALUES('{test_user}', 0, 0)".format(test_user=test_user)
+            "INSERT INTO users VALUES('{test_user}', 0, 0, '{{}}')".format(test_user=test_user)
         )
         self.assertTrue(self.test_db.user_exists(test_user))
 
@@ -138,7 +138,7 @@ class TestMSDatabase(unittest.TestCase):
     def test_delete_user(self):
         test_user = 'test_user_id'
         self.test_db.write(
-            "INSERT INTO users VALUES('{test_user}', 0, 0)".format(test_user=test_user)
+            "INSERT INTO users VALUES('{test_user}', 0, 0, '{{}}')".format(test_user=test_user)
         )
         self.test_db.query(
             "SELECT id FROM users where id = '{test_user}'".format(test_user=test_user)
@@ -269,11 +269,13 @@ class TestMSDatabase(unittest.TestCase):
 
     def insert_user(self, user):
         self.test_db.write(
-            ("INSERT INTO users VALUES('{mock_id}', {last_updated}, {last_spoiled})")
+            ("INSERT INTO users VALUES('{mock_id}', {last_updated}, {last_spoiled}, '{options}')")
             .format(
                 mock_id=user.user_id,
                 last_updated=user.last_updated,
-                last_spoiled=user.last_spoiled)
+                last_spoiled=user.last_spoiled,
+                options=user.options.to_json_string()
+            )
         )
 
     def insert_spoiler(self, spoiler):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -68,7 +68,7 @@ class TestWebhook(unittest.TestCase):
 
     @mock.patch('webhook.send_message')
     def test_send_spoiler_to(self, send_mock):
-        test_user = User((1234, 0, 0))
+        test_user = User((1234, 0, 0, '{}'))
         test_spoiler = Spoiler(('test', 123456, '2019-01-01', None))
 
         test_response = {
@@ -123,9 +123,9 @@ class TestWebhook(unittest.TestCase):
     def test_update_users(self, send_mock, db_mock):
         db = db_mock.return_value
 
-        alice = User(('Alice', 0, 0))
-        bob = User(('Bob', 4, 1))
-        dan = User(('Dan', 3, 3))
+        alice = User(('Alice', 0, 0, '{}'))
+        bob = User(('Bob', 4, 1, '{}'))
+        dan = User(('Dan', 3, 3, '{}'))
 
         db.get_all_unnotified_users.return_value = [alice, bob]
 
@@ -195,13 +195,13 @@ class TestWebhook(unittest.TestCase):
     @mock.patch('webhook.send_text_message')
     @mock.patch('webhook.send_spoiler_to')
     def test_handle_message_send_when_subbed(self, spoil_mock, send_mock, db_mock):
-        alice = User(('Alice', 5, 5))
+        alice = User(('Alice', 5, 5, '{}'))
         spoiler1 = Spoiler(('spoil1','attach1','2019-01-01',None))
         spoiler2 = Spoiler(('spoil2','attach2','2019-01-01',None))
         spoiler3 = Spoiler(('spoil3','attach3','2019-01-01',None))
         db = db_mock.return_value
         db.user_exists.return_value = True
-        db.get_user_from_id.return_value = User(('Alice', 5, 5))
+        db.get_user_from_id.return_value = User(('Alice', 5, 5, '{}'))
         latest_spoiler = 8
         db.get_latest_spoiler_id.return_value = latest_spoiler
         db.get_spoilers_later_than.return_value = []

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -134,10 +134,10 @@ class TestWebhook(unittest.TestCase):
                                           )
 
         # asap user
-        alice.options.update_mode = msbot.constants.ASAP_MODE
+        alice.options.update_mode = msbot.constants.ASAP_MODE_CMD
         webhook.update_user(alice)
         handle_mock.assert_called_once_with(alice.user_id,
-                                            msbot.constants.SEND)
+                                            msbot.constants.SEND_CMD)
 
         # unsupported mode
         send_mock.reset_mock()
@@ -183,7 +183,7 @@ class TestWebhook(unittest.TestCase):
         db.user_exists.return_value = False
         sender_psid = 1234
 
-        webhook.handle_message(sender_psid, msbot.constants.HELLO)
+        webhook.handle_message(sender_psid, msbot.constants.HELLO_CMD)
         send_mock.assert_called_once_with(
             sender_psid,
             { msbot.constants.TEXT: msbot.constants.RESP_SUBBED })
@@ -195,7 +195,7 @@ class TestWebhook(unittest.TestCase):
         db.user_exists.return_value = True
         sender_psid = 1234
 
-        webhook.handle_message(sender_psid, msbot.constants.HELLO)
+        webhook.handle_message(sender_psid, msbot.constants.HELLO_CMD)
         send_mock.assert_called_once_with(
             sender_psid,
             { msbot.constants.TEXT: msbot.constants.RESP_ALREADY_SUBBED })
@@ -207,7 +207,7 @@ class TestWebhook(unittest.TestCase):
         db.user_exists.return_value = False
         sender_psid = 1234
 
-        webhook.handle_message(sender_psid, msbot.constants.GOODBYE)
+        webhook.handle_message(sender_psid, msbot.constants.GOODBYE_CMD)
         send_mock.assert_called_once_with(
             sender_psid,
             { msbot.constants.TEXT: msbot.constants.RESP_ALREADY_UNSUBBED })
@@ -219,7 +219,7 @@ class TestWebhook(unittest.TestCase):
         db.user_exists.return_value = False
         sender_psid = 1234
 
-        webhook.handle_message(sender_psid, msbot.constants.SEND)
+        webhook.handle_message(sender_psid, msbot.constants.SEND_CMD)
         send_mock.assert_called_once_with(
             sender_psid,
             webhook.to_text_response(
@@ -244,7 +244,7 @@ class TestWebhook(unittest.TestCase):
         sender_psid = 1234
 
         # no new spoilers
-        webhook.handle_message(sender_psid, msbot.constants.SEND)
+        webhook.handle_message(sender_psid, msbot.constants.SEND_CMD)
         send_mock.assert_called_once_with(
             sender_psid,
             webhook.to_text_response(
@@ -259,7 +259,7 @@ class TestWebhook(unittest.TestCase):
             spoiler2,
             spoiler3,
         ]
-        webhook.handle_message(sender_psid, msbot.constants.SEND)
+        webhook.handle_message(sender_psid, msbot.constants.SEND_CMD)
         calls = [
             mock.call(alice, spoiler1),
             mock.call(alice, spoiler2),
@@ -282,7 +282,7 @@ class TestWebhook(unittest.TestCase):
         db.user_exists.return_value = False
         sender_psid = 1234
 
-        webhook.handle_message(sender_psid, msbot.constants.RECENT)
+        webhook.handle_message(sender_psid, msbot.constants.RECENT_CMD)
         send_mock.assert_called_once_with(
             sender_psid,
             webhook.to_text_response(
@@ -314,7 +314,7 @@ class TestWebhook(unittest.TestCase):
         sender_psid = 1234
 
         # new spoilers
-        webhook.handle_message(sender_psid, msbot.constants.RECENT)
+        webhook.handle_message(sender_psid, msbot.constants.RECENT_CMD)
         calls = [
             mock.call(alice, spoiler1),
             mock.call(alice, spoiler2),
@@ -340,7 +340,7 @@ class TestWebhook(unittest.TestCase):
         db.user_exists.return_value = True
         sender_psid = 1234
 
-        webhook.handle_message(sender_psid, msbot.constants.GOODBYE)
+        webhook.handle_message(sender_psid, msbot.constants.GOODBYE_CMD)
         send_mock.assert_called_once_with(
             sender_psid,
             { msbot.constants.TEXT: msbot.constants.RESP_UNSUBBED })

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -213,7 +213,7 @@ class TestWebhook(unittest.TestCase):
             { msbot.constants.TEXT: msbot.constants.RESP_ALREADY_UNSUBBED })
 
     @mock.patch('msbot.msdb.MSDatabase')
-    @mock.patch('webhook.send_text_message')
+    @mock.patch('webhook.send_message')
     def test_handle_message_send_when_unsubbed(self, send_mock, db_mock):
         db = db_mock.return_value
         db.user_exists.return_value = False
@@ -222,10 +222,13 @@ class TestWebhook(unittest.TestCase):
         webhook.handle_message(sender_psid, msbot.constants.SEND)
         send_mock.assert_called_once_with(
             sender_psid,
-            msbot.constants.RESP_INVALID_UNSUBBED)
+            webhook.to_text_response(
+                msbot.constants.RESP_INVALID_UNSUBBED
+            )
+        )
 
     @mock.patch('msbot.msdb.MSDatabase')
-    @mock.patch('webhook.send_text_message')
+    @mock.patch('webhook.send_message')
     @mock.patch('webhook.send_spoiler_to')
     def test_handle_message_send_when_subbed(self, spoil_mock, send_mock, db_mock):
         alice = User(('Alice', 5, 5, '{}'))
@@ -244,7 +247,10 @@ class TestWebhook(unittest.TestCase):
         webhook.handle_message(sender_psid, msbot.constants.SEND)
         send_mock.assert_called_once_with(
             sender_psid,
-            msbot.constants.RESP_UPDATE_UPDATED)
+            webhook.to_text_response(
+                msbot.constants.RESP_UPDATE_UPDATED
+            )
+        )
 
         # new spoilers
         send_mock.reset_mock()
@@ -263,11 +269,14 @@ class TestWebhook(unittest.TestCase):
         self.assertEqual(spoil_mock.call_count, len(calls))
         send_mock.assert_called_once_with(
             sender_psid,
-            msbot.constants.RESP_UPDATE_COMPLETE)
+            webhook.to_text_response(
+                msbot.constants.RESP_UPDATE_COMPLETE
+            )
+        )
         db.update_user.called_once_with(alice.user_id, latest_spoiler)
 
     @mock.patch('msbot.msdb.MSDatabase')
-    @mock.patch('webhook.send_text_message')
+    @mock.patch('webhook.send_message')
     def test_handle_message_recent_when_unsubbed(self, send_mock, db_mock):
         db = db_mock.return_value
         db.user_exists.return_value = False
@@ -276,10 +285,13 @@ class TestWebhook(unittest.TestCase):
         webhook.handle_message(sender_psid, msbot.constants.RECENT)
         send_mock.assert_called_once_with(
             sender_psid,
-            msbot.constants.RESP_INVALID_UNSUBBED)
+            webhook.to_text_response(
+                msbot.constants.RESP_INVALID_UNSUBBED
+            )
+        )
 
     @mock.patch('msbot.msdb.MSDatabase')
-    @mock.patch('webhook.send_text_message')
+    @mock.patch('webhook.send_message')
     @mock.patch('webhook.send_spoiler_to')
     def test_handle_message_recent_when_subbed(self, spoil_mock, send_mock, db_mock):
         alice = User(('Alice', 8, 8, '{}'))
@@ -312,7 +324,9 @@ class TestWebhook(unittest.TestCase):
         self.assertEqual(spoil_mock.call_count, len(calls))
         send_mock.assert_called_once_with(
             sender_psid,
-            msbot.constants.RESP_LAST_SPOILER_INFO.format(date_string=latest_date)
+            webhook.to_text_response(
+                msbot.constants.RESP_LAST_SPOILER_INFO.format(date_string=latest_date)
+            )
         )
         db.update_user.called_once_with(alice.user_id,
                                         latest_spoiler,
@@ -341,7 +355,10 @@ class TestWebhook(unittest.TestCase):
         webhook.handle_message(sender_psid, 'unsupported_message')
         send_mock.assert_called_once_with(
             sender_psid,
-            { msbot.constants.TEXT: msbot.constants.RESP_INVALID_SUBBED })
+            webhook.to_text_response(
+                msbot.constants.RESP_INVALID_SUBBED
+            )
+        )
 
     @mock.patch('msbot.msdb.MSDatabase')
     @mock.patch('webhook.send_message')
@@ -353,7 +370,8 @@ class TestWebhook(unittest.TestCase):
         webhook.handle_message(sender_psid, 'unsupported_message')
         send_mock.assert_called_once_with(
             sender_psid,
-            { msbot.constants.TEXT: msbot.constants.RESP_INVALID_UNSUBBED })
+            webhook.to_text_response(msbot.constants.RESP_INVALID_UNSUBBED)
+        )
 
     def test_webhook_event_text_message_received(self):
         with boddle(

--- a/webhook.py
+++ b/webhook.py
@@ -46,12 +46,15 @@ def text_quick_reply_response(text, buttons):
 
 # TODO: Refactor this to take in a user object and a last spoiled id
 # Also write a test for it
+UPDATE_BUTTONS = [
+    create_quick_reply_button(msbot.constants.SEND_CMD),
+    create_quick_reply_button(msbot.constants.RECENT_CMD),
+]
 def send_update(sender_psid, text):
-    buttons = [
-        create_quick_reply_button(msbot.constants.SEND_CMD),
-        create_quick_reply_button(msbot.constants.RECENT_CMD),
-    ]
-    send_message(sender_psid, text_quick_reply_response(text, buttons))
+    send_message(
+        sender_psid,
+        text_quick_reply_response(text, UPDATE_BUTTONS)
+    )
 
 def get_attach_id_for(image_url):
     print('Getting attach id for ', image_url)
@@ -135,6 +138,10 @@ def update():
         update_users()
 
 #Handle messages received from user
+UPDATE_MODE_BUTTONS = [
+    create_quick_reply_button(msbot.constants.POLL_MODE_CMD),
+    create_quick_reply_button(msbot.constants.ASAP_MODE_CMD),
+]
 def handle_message(sender_psid, received_message):
     database = msbot.msdb.MSDatabase(db_file)
     def subscribe(sender_psid):
@@ -184,11 +191,7 @@ def handle_message(sender_psid, received_message):
             text = msbot.constants.RESP_MODE_PROMPT.format(
                     update_mode=user.options.update_mode
                 )
-            buttons = [
-                create_quick_reply_button(msbot.constants.POLL_MODE_CMD),
-                create_quick_reply_button(msbot.constants.ASAP_MODE_CMD),
-            ]
-            return text_quick_reply_response(text, buttons)
+            return text_quick_reply_response(text, UPDATE_MODE_BUTTONS)
         return to_text_response(msbot.constants.RESP_INVALID_UNSUBBED)
 
     def change_update_mode(sender_psid, mode):

--- a/webhook.py
+++ b/webhook.py
@@ -41,15 +41,18 @@ def create_quick_reply_button(payload):
         msbot.constants.PAYLOAD: payload,
     }
 
-def send_update(sender_psid, text):
-    resp = {
+def text_quick_reply_response(text, buttons):
+    return {
         msbot.constants.TEXT: text,
-        msbot.constants.QUICK_REPLIES: [
-            create_quick_reply_button(msbot.constants.SEND),
-            create_quick_reply_button(msbot.constants.RECENT),
-        ]
+        msbot.constants.QUICK_REPLIES: buttons
     }
-    send_message(sender_psid, resp)
+
+def send_update(sender_psid, text):
+    buttons = [
+        create_quick_reply_button(msbot.constants.SEND_CMD),
+        create_quick_reply_button(msbot.constants.RECENT_CMD),
+    ]
+    send_message(sender_psid, text_quick_reply_response(text, buttons))
 
 def get_attach_id_for(image_url):
     print('Getting attach id for ', image_url)
@@ -103,11 +106,11 @@ def update_user(user):
         send_update(user.user_id, resp)
 
     def asap(user):
-        handle_message(user.user_id, msbot.constants.SEND)
+        handle_message(user.user_id, msbot.constants.SEND_CMD)
 
     update_modes = {
-        msbot.constants.POLL_MODE: lambda user: poll(user),
-        msbot.constants.ASAP_MODE: lambda user: asap(user),
+        msbot.constants.POLL_MODE_CMD: lambda user: poll(user),
+        msbot.constants.ASAP_MODE_CMD: lambda user: asap(user),
     }
 
     user_mode = user.options.update_mode
@@ -177,11 +180,13 @@ def handle_message(sender_psid, received_message):
         return msbot.constants.RESP_INVALID_UNSUBBED
 
     responses = {
-        msbot.constants.HELLO: lambda id: to_text_response(subscribe(id)),
-        msbot.constants.GOODBYE: lambda id: to_text_response(unsubscribe(id)),
-        msbot.constants.SEND: lambda id: to_text_response(send(id)),
-        msbot.constants.RECENT: lambda id: to_text_response(recent(id)),
+        msbot.constants.HELLO_CMD: lambda id: to_text_response(subscribe(id)),
+        msbot.constants.GOODBYE_CMD: lambda id: to_text_response(unsubscribe(id)),
+        msbot.constants.SEND_CMD: lambda id: to_text_response(send(id)),
+        msbot.constants.RECENT_CMD: lambda id: to_text_response(recent(id)),
+        msbot.constants.MODE_CMD: lambda id: mode(id),
     }
+
     message = received_message.lower()
     if message in responses:
         resp = responses[message](sender_psid)

--- a/webhook.py
+++ b/webhook.py
@@ -31,6 +31,9 @@ def send_message(sender_psid, response):
 def send_text_message(sender_psid, text):
     send_message(sender_psid, { msbot.constants.TEXT: text})
 
+def to_text_response(text):
+    return { msbot.constants.TEXT: text }
+
 def create_quick_reply_button(payload):
     return {
         msbot.constants.CONTENT_TYPE: msbot.constants.TEXT,
@@ -174,10 +177,10 @@ def handle_message(sender_psid, received_message):
         return msbot.constants.RESP_INVALID_UNSUBBED
 
     responses = {
-        msbot.constants.HELLO: lambda id: subscribe(id),
-        msbot.constants.GOODBYE: lambda id: unsubscribe(id),
-        msbot.constants.SEND: lambda id: send(id),
-        msbot.constants.RECENT: lambda id: recent(id),
+        msbot.constants.HELLO: lambda id: to_text_response(subscribe(id)),
+        msbot.constants.GOODBYE: lambda id: to_text_response(unsubscribe(id)),
+        msbot.constants.SEND: lambda id: to_text_response(send(id)),
+        msbot.constants.RECENT: lambda id: to_text_response(recent(id)),
     }
     message = received_message.lower()
     if message in responses:
@@ -186,8 +189,9 @@ def handle_message(sender_psid, received_message):
         resp = msbot.constants.RESP_INVALID_UNSUBBED
         if database.user_exists(sender_psid):
             resp = msbot.constants.RESP_INVALID_SUBBED
+        resp = to_text_response(resp)
 
-    send_text_message(sender_psid, resp)
+    send_message(sender_psid, resp)
 
 def handle_postback(sender_psid, received_postback):
     pass


### PR DESCRIPTION
This PR implements #21 in its entirety and shifts over some of the interaction to quick replies as per #23 

With this PR user option information is stored as a JSON blob in sqlite and the MODE, POLL, and ASAP commands are added to access the change mode menus.