### PR TITLE
Threads handle_message to respond to FB within 20s

### DIFF
--- a/webhook.py
+++ b/webhook.py
@@ -251,7 +251,14 @@ def webhook_event():
             if event[msbot.constants.MESSAGE]:
                 try:
                     if sender_psid in msbot.settings.DEV_SAFELIST:
-                        handle_message(sender_psid, event[msbot.constants.MESSAGE][msbot.constants.TEXT])
+                        handle_thread = Thread(
+                            target = handle_message, args=(
+                                sender_psid,
+                                event[msbot.constants.MESSAGE][msbot.constants.TEXT]
+                            )
+                        )
+                        handle_thread.setDaemon(True)
+                        handle_thread.start()
                 except KeyError:
                     print('Non-text message received')
             elif event[msbot.constants.POSTBACK]:


### PR DESCRIPTION
The old implementation blocked until the handle_message function
terminated, resulting in unacceptable wait times that would cause
Facebook to resend messages, causing an infinite loop.

Fixes #27 